### PR TITLE
CPM movement v2

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1589,6 +1589,7 @@ typedef struct {
     int		delagMissileMaxLatency;
     int		predictedMissileNudge;
     int		ratFlags;
+    int		movement;
     float	maxBrightshellAlpha;
     int		timeoutEnd;
     int		timeoutOvertime;
@@ -1705,7 +1706,7 @@ extern  vmCvar_t		cg_scorePlum;
 
 extern vmCvar_t                	cg_ratInitialized;
 
-extern vmCvar_t                	g_ratPhysics;
+extern vmCvar_t                	g_movement;
 extern vmCvar_t                	g_rampJump;
 extern vmCvar_t                	g_additiveJump;
 extern vmCvar_t                	g_swingGrapple;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -199,7 +199,7 @@ vmCvar_t 	cg_scorePlum;
 
 vmCvar_t 	cg_ratInitialized;
 
-vmCvar_t 	g_ratPhysics;
+vmCvar_t 	g_movement;
 vmCvar_t 	g_rampJump;
 vmCvar_t 	g_additiveJump;
 vmCvar_t 	g_swingGrapple;
@@ -626,7 +626,7 @@ static cvarTable_t cvarTable[] = { // bk001129
 	// RAT ===================
 	{ &cg_ratInitialized, "cg_ratInitialized", "0", CVAR_ARCHIVE},
 
-	{ &g_ratPhysics, "g_ratPhysics", "0", CVAR_SYSTEMINFO},
+	{ &g_movement, "g_movement", "0", CVAR_SERVERINFO},
 	{ &g_rampJump, "g_rampJump", "0", CVAR_SYSTEMINFO},
 	{ &g_additiveJump, "g_additiveJump", "0", CVAR_SYSTEMINFO},
 	{ &g_swingGrapple, "g_swingGrapple", "0", CVAR_SYSTEMINFO},

--- a/code/cgame/cg_predict.c
+++ b/code/cgame/cg_predict.c
@@ -572,8 +572,10 @@ static void CG_TouchTriggerPrediction( void ) {
 					cg.predictedPlayerState.pm_time = 160;
 					cg.predictedPlayerState.pm_flags |= PMF_TIME_KNOCKBACK;
 
-					// reset rampjump
-					cg.predictedPlayerState.stats[STAT_JUMPTIME] = 0;
+					if (cgs.movement == RAT_MOVEMENT_RM) {
+						// reset rampjump
+						cg.predictedPlayerState.stats[STAT_JUMPTIME] = 0;
+					}
 
 					// set the delta angle
 					for (i=0 ; i<3 ; i++) {
@@ -857,6 +859,7 @@ void CG_PredictPlayerState( void ) {
         cg_pmove.pmove_float = pmove_float.integer;
         cg_pmove.pmove_flags = cgs.dmflags;
         cg_pmove.pmove_ratflags = cgs.ratFlags;
+        cg_pmove.pmove_movement = cgs.movement;
         
 
 //unlagged - optimized prediction

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -1056,7 +1056,12 @@ void CG_ParseServerinfo( void ) {
 	cgs.ratFlags = atoi( Info_ValueForKey( info, "g_ratFlags" ) );
 	trap_Cvar_Set("g_ratFlags", va("%i", cgs.ratFlags));
 
-	trap_Cvar_Set("g_ratPhysics", va("%i", (cgs.ratFlags & RAT_RATPHYSICS) ? 1 : 0));
+	cgs.movement = atoi( Info_ValueForKey( info, "g_movement" ) );
+	if ((cgs.movement > RAT_MOVEMENT_RM) || (cgs.movement < RAT_MOVEMENT_VQ3)) {
+		cgs.movement = RAT_MOVEMENT_VQ3;
+	}
+	trap_Cvar_Set("g_movement", va("%i", cgs.movement));
+
 	trap_Cvar_Set("g_rampJump", va("%i", (cgs.ratFlags & RAT_RAMPJUMP) ? 1 : 0));
 	trap_Cvar_Set("g_additiveJump", va("%i", (cgs.ratFlags & RAT_ADDITIVEJUMP) ? 1 : 0));
 	trap_Cvar_Set("g_fastSwim", va("%i", (cgs.ratFlags & RAT_FASTSWIM) ? 1 : 0));

--- a/code/game/bg_local.h
+++ b/code/game/bg_local.h
@@ -57,19 +57,19 @@ extern	pmove_t		*pm;
 extern	pml_t		pml;
 
 // movement parameters
-extern	float	pm_stopspeed;
-extern	float	pm_duckScale;
-extern	float	pm_swimScale;
-extern	float	pm_wadeScale;
+extern	const float	pm_stopspeed;
+extern	const float	pm_duckScale;
+extern	const float	pm_swimScale;
+extern	const float	pm_wadeScale;
 
-extern	float	pm_accelerate;
-extern	float	pm_airaccelerate;
-extern	float	pm_wateraccelerate;
-extern	float	pm_flyaccelerate;
+extern	const float	pm_accelerate;
+extern	const float	pm_airaccelerate;
+extern	const float	pm_wateraccelerate;
+extern	const float	pm_flyaccelerate;
 
-extern	float	pm_friction;
-extern	float	pm_waterfriction;
-extern	float	pm_flightfriction;
+extern	const float	pm_friction;
+extern	const float	pm_waterfriction;
+extern	const float	pm_flightfriction;
 
 extern	int		c_pmove;
 

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -220,6 +220,8 @@ typedef struct {
         int                     pmove_flags;
         //more flags affecting movement (see g_ratFlags)
         int                     pmove_ratflags;
+        // Selects between VQ3, CPM, and RM.
+        int                     pmove_movement;
 
 	// callbacks to test the world
 	// these will be different functions during game and cgame
@@ -840,7 +842,7 @@ qboolean	BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
 #define RAT_PREDICTMISSILES 	(1 << 3)
 #define RAT_FASTSWITCH 		(1 << 4)
 #define RAT_FASTWEAPONS 	(1 << 5)
-#define RAT_RATPHYSICS 		(1 << 6)
+// #define RAT_RATPHYSICS 		(1 << 6)
 #define RAT_RAMPJUMP 		(1 << 7)
 #define RAT_ALLOWFORCEDMODELS 	(1 << 8)
 #define RAT_FRIENDSWALLHACK 	(1 << 9)
@@ -865,6 +867,10 @@ qboolean	BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
 
 #define SCORE_RATINDICATOR_HASRAT  	1
 #define SCORE_RATINDICATOR_ISREGISTERED 2
+
+#define RAT_MOVEMENT_VQ3	0
+#define RAT_MOVEMENT_CPM	1
+#define RAT_MOVEMENT_RM		2
 
 // for treasure hunter
 typedef enum {

--- a/code/game/bg_slidemove.c
+++ b/code/game/bg_slidemove.c
@@ -224,6 +224,16 @@ qboolean	PM_SlideMove( qboolean gravity ) {
 	return ( bumpcount != 0 );
 }
 
+static float PM_GetUpStepVelocityCap(pmove_t *pm) {
+	switch (pm->pmove_movement) {
+	case RAT_MOVEMENT_CPM:
+		return 25.0f * pm->ps->gravity * pml.frametime;
+	// case MOVEMENT_RM:
+	// 	return 0.0f;
+	}
+	return 0.0f;
+}
+
 /*
 ==================
 PM_StepSlideMove
@@ -250,8 +260,8 @@ void PM_StepSlideMove( qboolean gravity ) {
 	down[2] -= STEPSIZE;
 	pm->trace (&trace, start_o, pm->mins, pm->maxs, down, pm->ps->clientNum, pm->tracemask);
 	VectorSet(up, 0, 0, 1);
-	// never step up when you still have up velocity
-	if ( pm->ps->velocity[2] > 0 && (trace.fraction == 1.0 ||
+	// almost never step up when you still have up velocity
+	if ( pm->ps->velocity[2] > PM_GetUpStepVelocityCap(pm) && (trace.fraction == 1.0 ||
 										DotProduct(trace.plane.normal, up) < 0.7)) {
 		return;
 	}

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -1483,6 +1483,7 @@ void ClientThink_real( gentity_t *ent ) {
         pm.pmove_float = pmove_float.integer;
         pm.pmove_flags = g_dmflags.integer;
         pm.pmove_ratflags = g_ratFlags.integer;
+        pm.pmove_movement = g_movement.integer;
 
 	VectorCopy( client->ps.origin, client->oldOrigin );
 

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -704,6 +704,21 @@ void Cmd_Acc_f( gentity_t *ent ) {
 ==================
 */
 void Cmd_Rules_f( gentity_t *ent ) {
+	char *movement = NULL;
+	switch (g_movement.integer) {
+	// case RAT_MOVEMENT_VQ3:
+	// 	movement = "VQ3";
+	// 	break;
+	case RAT_MOVEMENT_CPM:
+		movement = "CPM";
+		break;
+	case RAT_MOVEMENT_RM:
+		movement = "RM";
+		break;
+	default:
+		movement = "VQ3";
+	}
+	
 	trap_SendServerCommand( ent-g_entities, va("print \""
 				"Server rules:\n"
 				" -Fast weapon switch:    %s" S_COLOR_WHITE "\n"
@@ -715,7 +730,7 @@ void Cmd_Rules_f( gentity_t *ent ) {
 				" -Item pickup height:    %s" S_COLOR_WHITE "\n"
 				" -Powerup glows:         %s" S_COLOR_WHITE "\n"
 				" -Screen shake upon hit: %s" S_COLOR_WHITE "\n"
-				" -Rat physics:           %s" S_COLOR_WHITE "\n"
+				" -movement:              " S_COLOR_WHITE "%s\n"
 				" -Jumppad grenades:      %s" S_COLOR_WHITE "\n"
 				" -Tele missiles:         %s" S_COLOR_WHITE "\n"
 				"\"", 
@@ -728,7 +743,7 @@ void Cmd_Rules_f( gentity_t *ent ) {
 				g_itemPickup.integer ? "high" : "low",
 				g_powerupGlows.integer ? S_COLOR_GREEN "ON" : S_COLOR_RED "OFF",
 				g_screenShake.integer ? S_COLOR_GREEN "ON" : S_COLOR_RED "OFF",
-				g_ratPhysics.integer ? S_COLOR_GREEN "ON" : S_COLOR_RED "OFF",
+				movement,
 				g_pushGrenades.integer ? S_COLOR_GREEN "ON" : S_COLOR_RED "OFF",
 				g_teleMissiles.integer ? S_COLOR_GREEN "ON" : S_COLOR_RED "OFF"
 

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1597,7 +1597,7 @@ extern  vmCvar_t        g_teleMissiles;
 extern  vmCvar_t        g_teleMissilesMaxTeleports;
 extern  vmCvar_t        g_pushGrenades;
 extern  vmCvar_t        g_newShotgun;
-extern  vmCvar_t        g_ratPhysics;
+extern  vmCvar_t        g_movement;
 extern  vmCvar_t        g_rampJump;
 extern  vmCvar_t        g_additiveJump;
 extern  vmCvar_t        g_fastSwim;

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -241,7 +241,7 @@ vmCvar_t        g_teleMissiles;
 vmCvar_t        g_teleMissilesMaxTeleports;
 vmCvar_t        g_pushGrenades;
 vmCvar_t        g_newShotgun;
-vmCvar_t        g_ratPhysics;
+vmCvar_t        g_movement;
 vmCvar_t        g_rampJump;
 vmCvar_t        g_additiveJump;
 vmCvar_t        g_fastSwim;
@@ -615,7 +615,7 @@ static cvarTable_t		gameCvarTable[] = {
 
         { &g_newShotgun, "g_newShotgun", "1", CVAR_ARCHIVE, 0, qtrue },
 
-	{ &g_ratPhysics,   "g_ratPhysics", "0", CVAR_ARCHIVE, 0, qtrue },
+	{ &g_movement,   "g_movement", "0", CVAR_ARCHIVE | CVAR_SERVERINFO, 0, qtrue },
 	{ &g_rampJump,     "g_rampJump", "0", CVAR_ARCHIVE, 0, qtrue },
 	{ &g_additiveJump,     "g_additiveJump", "0", CVAR_ARCHIVE, 0, qtrue },
 	{ &g_fastSwim,   "g_fastSwim", "1", CVAR_ARCHIVE, 0, qtrue },
@@ -1504,9 +1504,9 @@ void G_UpdateRatFlags( void ) {
 		rflags |= RAT_FASTWEAPONS;
 	}
 
-	if (g_ratPhysics.integer == 1) {
-		rflags |= RAT_RATPHYSICS;
-	}
+	// if (g_ratPhysics.integer == 1) {
+	// 	rflags |= RAT_RATPHYSICS;
+	// }
 
 	if (g_rampJump.integer) {
 		rflags |= RAT_RAMPJUMP;
@@ -1668,7 +1668,7 @@ void G_UpdateCvars( void ) {
 						|| cv->vmCvar == &g_predictMissiles
 						|| cv->vmCvar == &g_fastSwitch
 						|| cv->vmCvar == &g_fastWeapons
-						|| cv->vmCvar == &g_ratPhysics
+						// || cv->vmCvar == &g_ratPhysics
 						|| cv->vmCvar == &g_rampJump
 						|| cv->vmCvar == &g_allowForcedModels
 						|| cv->vmCvar == &g_friendsWallHack
@@ -5249,7 +5249,7 @@ void G_SetRuleset(int ruleset) {
 		trap_Cvar_Set("g_fastSwitch", "1");
 		trap_Cvar_Set("g_fastWeapons", "1");
 		trap_Cvar_Set("g_additiveJump", "1");
-		trap_Cvar_Set("g_ratPhysics", "0");
+		trap_Cvar_Set("g_movement", "0");
 		trap_Cvar_Set("g_rampJump", "0");
 		trap_Cvar_Set("g_itemPickup", "1");
 		trap_Cvar_Set("g_screenShake", "0");
@@ -5259,7 +5259,7 @@ void G_SetRuleset(int ruleset) {
 		trap_Cvar_Set("g_fastSwitch", "0");
 		trap_Cvar_Set("g_fastWeapons", "1");
 		trap_Cvar_Set("g_additiveJump", "0");
-		trap_Cvar_Set("g_ratPhysics", "0");
+		trap_Cvar_Set("g_movement", "0");
 		trap_Cvar_Set("g_rampJump", "0");
 		trap_Cvar_Set("g_itemPickup", "1");
 		trap_Cvar_Set("g_screenShake", "0");

--- a/code/game/g_misc.c
+++ b/code/game/g_misc.c
@@ -111,8 +111,10 @@ void TeleportPlayer( gentity_t *player, vec3_t origin, vec3_t angles ) {
 	// toggle the teleport bit so the client knows to not lerp
 	player->client->ps.eFlags ^= EF_TELEPORT_BIT;
 
-	// reset rampjump
-	player->client->ps.stats[STAT_JUMPTIME] = 0;
+	if (g_movement.integer == RAT_MOVEMENT_RM) {
+		// reset rampjump
+		player->client->ps.stats[STAT_JUMPTIME] = 0;
+	}
 
 
 	// kill anything at the destination


### PR DESCRIPTION
Continuation of [this](https://github.com/rdntcntrl/ratoa_gamecode/pull/4#issuecomment-913558334).

I believe I have fixed everything you mentioned in your last message.

> Since these flags (vq3/cpm/rm) are mutually exclusive maybe we should just make it a serverinfo cvar instead of stuffing it into ratFlags after all.

g_movement is now declared as CVAR_SERVERINFO on the server. Is that all that needed to be done?

> I would also suggest using Q_stricmp() instead of Q_strequal() so it's case-insensitive (as most things are in the game).

Done. g_movement is an integer now though, so this only happens for viewing server rules.

>  I think it would be best if you omit the reset only if movement == cpm.

Done. I think I only included it for RM, but it has the same effect.

> Finally, it would be good to rename the CL_* functions you added in bg_pmove.c to have a different prefix (like PM).

Done.