### PR TITLE
Make stairs horrible.

### DIFF
--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -259,7 +259,8 @@ typedef enum {
 	STAT_EXTFLAGS,					// extended playerstate flags
 	STAT_BOBCYCLEREM,				// used to store fractions of bobCycle for consistent, FPS-independent footsteps
 	STAT_OVERBOUNCE,					// Overbounce flag (only 1 bit, this could be integrated into another bitflag field if more STAT_ fields are required)
-	STAT_FROZENSTATE				// used to store frozen/thawing state if g_freeze = 1
+	STAT_FROZENSTATE,				// used to store frozen/thawing state if g_freeze = 1
+	STAT_WALKTIME
 } statIndex_t;
 
 

--- a/code/game/bg_slidemove.c
+++ b/code/game/bg_slidemove.c
@@ -298,6 +298,9 @@ void PM_StepSlideMove( qboolean gravity ) {
 	}
 	if ( trace.fraction < 1.0 ) {
 		if (pm->pmove_ratflags & RAT_SMOOTHSTAIRS) {
+			if (DotProduct(pm->ps->velocity, trace.plane.normal) > 0) {
+				pm->ps->stats[STAT_WALKTIME] = 100;
+			}
 			PM_OneSidedClipVelocity( pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP );
 		} else {
 			PM_ClipVelocity( pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP );


### PR DESCRIPTION
These stairs feel a lot closer to Q3 stairs, but RJs will still happen 100% of the time.
There is a timer (currently set to 100 ms) that forces calls to PM_WalkMove for a time after a step. A jump clears this timer.
If the player presses jump during the walk period, then a jump will occur, even if the player is in the air. If the time period is too long (100 ms may be too long) then it should be possible to RJ and jump again while high in the air, giving extra height.