### PR TITLE
game: add missing guard clause in G_EQPingClientSet

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -1124,6 +1124,10 @@ void G_EQPingClientReset(gclient_t *client) {
 }
 
 void G_EQPingClientSet(gclient_t *client) {
+	if (!g_usesRatEngine.integer || !trap_Cvar_VariableIntegerValue("sv_eqping")) {
+		return;
+	}
+
 	if (client->pers.realPing < level.eqPing) {
 		trap_RAT_EQPing_SetDelay(client - g_clients, level.eqPing - client->pers.realPing);
 	} else {


### PR DESCRIPTION
How to reproduce
1. run ratmod with oa's engine. "seta g_usesRatEngine 0"
2. join server
3. disconnect
4. Server crashes:
```
********************
ERROR: Bad game system trap: 583
********************
----- Server Shutdown (Server crashed: Bad game system trap: 583) -----
```