### PR TITLE
Add movement key presses to the HUD.

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -2200,6 +2200,77 @@ static void CG_DrawHudDamageIndicator(void) {
 
 }
 
+#define HUD_MOVEMENT_SIZE (48)
+static void CG_DrawMovementKeys(void) {
+	float color[4] = { 1.0, 1.0, 1.0, 1.0 };
+	float hue, sat, val;
+	float x,y, w, h;
+	qboolean left, right, up, down, jump, crouch;
+	float size = HUD_MOVEMENT_SIZE * cg_hudMovementKeysScale.value;
+
+
+	if (cg_hudMovementKeys.integer != 1) {
+		return;
+	}
+
+	if ( !cg.snap ) {
+		return;
+	}
+
+	CG_PlayerColorFromString(cg_hudMovementKeysColor.string, &hue, &sat, &val);
+	Q_HSV2RGB(hue,sat,val, color);
+	trap_R_SetColor(color);
+
+	jump   = cg.snap->ps.stats[STAT_MOVEMENT_KEYS] & MOVEMENT_KEY_JUMP;
+	crouch = cg.snap->ps.stats[STAT_MOVEMENT_KEYS] & MOVEMENT_KEY_CROUCH;
+	up     = cg.snap->ps.stats[STAT_MOVEMENT_KEYS] & MOVEMENT_KEY_UP;
+	down   = cg.snap->ps.stats[STAT_MOVEMENT_KEYS] & MOVEMENT_KEY_DOWN;
+	left   = cg.snap->ps.stats[STAT_MOVEMENT_KEYS] & MOVEMENT_KEY_LEFT;
+	right  = cg.snap->ps.stats[STAT_MOVEMENT_KEYS] & MOVEMENT_KEY_RIGHT;
+
+	if (!(left || up || down || right || crouch || jump)) {
+		return;
+	}
+
+	h = size;
+	w = CG_HeightToWidth(h);
+	x = (SCREEN_WIDTH - w)/2.0;
+	y = (SCREEN_HEIGHT - h)/2.0 + h;
+	if (down) {
+		// down
+		CG_DrawPic( x, y, w, h, cgs.media.movementKeyIndicatorDown );
+	}
+	if (crouch) {
+		// crouch
+		CG_DrawPic( x, y + h/4.0, w, h, cgs.media.movementKeyIndicatorCrouch );
+	}
+	y = (SCREEN_HEIGHT - h)/2.0 - h;
+	if (up) {
+		// up
+		CG_DrawPic( x, y, w, h, cgs.media.movementKeyIndicatorUp );
+	}
+	if (jump) {
+		// jump
+		// y = 0 - h * offsetFactor;
+		CG_DrawPic( x, y - h/4.0, w, h, cgs.media.movementKeyIndicatorJump );
+	}
+	w = CG_HeightToWidth(size);
+	y = (SCREEN_HEIGHT - h)/2.0;
+	if (left) {
+		// left
+		x = (SCREEN_WIDTH - w)/2.0 - w;
+		CG_DrawPic( x, y, w, h, cgs.media.movementKeyIndicatorLeft );
+	}
+	if (right) {
+		// right
+		x = (SCREEN_WIDTH - w)/2.0 + w;
+		CG_DrawPic( x, y, w, h, cgs.media.movementKeyIndicatorRight );
+	}
+
+	trap_R_SetColor(NULL);
+
+}
+
 /*
 ===========================================================================================
 
@@ -6622,6 +6693,7 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 				CG_DrawRatStatusBar4Bg();
 			}
 			CG_DrawHudDamageIndicator();
+			CG_DrawMovementKeys();
 
 #ifdef MISSIONPACK
 			if ( cg_drawStatus.integer ) {

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -938,6 +938,13 @@ typedef struct {
 	qhandle_t	damageIndicatorTop;
 	qhandle_t	damageIndicatorRight;
 	qhandle_t	damageIndicatorLeft;
+	
+	qhandle_t	movementKeyIndicatorJump;
+	qhandle_t	movementKeyIndicatorCrouch;
+	qhandle_t	movementKeyIndicatorUp;
+	qhandle_t	movementKeyIndicatorDown;
+	qhandle_t	movementKeyIndicatorLeft;
+	qhandle_t	movementKeyIndicatorRight;
 
 	qhandle_t	bardot;
 	qhandle_t	bardot_additiveglow;
@@ -1753,6 +1760,9 @@ extern vmCvar_t			cg_hudDamageIndicator;
 extern vmCvar_t			cg_hudDamageIndicatorScale;
 extern vmCvar_t			cg_hudDamageIndicatorOffset;
 extern vmCvar_t			cg_hudDamageIndicatorAlpha;
+extern vmCvar_t			cg_hudMovementKeys;
+extern vmCvar_t			cg_hudMovementKeysScale;
+extern vmCvar_t			cg_hudMovementKeysColor;
 extern vmCvar_t			cg_emptyIndicator;
 extern vmCvar_t			cg_reloadIndicator;
 extern vmCvar_t			cg_reloadIndicatorY;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -36,7 +36,10 @@ int teamSoundModificationCount = -1;
 int enemySoundModificationCount = -1;
 int forceColorModificationCounts = -1;
 int ratStatusbarModificationCount = -1;
+int hudMovementKeysModificationCount = -1;
+qboolean hudMovementKeysRegistered = qfalse;
 
+static void CG_RegisterMovementKeysShaders(void);
 static void CG_RegisterNumbers(void);
 void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum );
 void CG_Shutdown( void );
@@ -683,7 +686,7 @@ static cvarTable_t cvarTable[] = { // bk001129
 	{ &cg_hudDamageIndicatorScale, "cg_hudDamageIndicatorScale", "1.0", CVAR_ARCHIVE},
 	{ &cg_hudDamageIndicatorOffset, "cg_hudDamageIndicatorOffset", "0.0", CVAR_ARCHIVE},
 	{ &cg_hudDamageIndicatorAlpha, "cg_hudDamageIndicatorAlpha", "1.0", CVAR_ARCHIVE},
-	{ &cg_hudMovementKeys, "cg_hudMovementKeys", "0", CVAR_ARCHIVE | CVAR_LATCH},
+	{ &cg_hudMovementKeys, "cg_hudMovementKeys", "0", CVAR_ARCHIVE},
 	{ &cg_hudMovementKeysScale, "cg_hudMovementKeysScale", "1.0", CVAR_ARCHIVE},
 	{ &cg_hudMovementKeysColor, "cg_hudMovementKeysColor", "H0 0.0 1.0", CVAR_ARCHIVE},
 	{ &cg_emptyIndicator, "cg_emptyIndicator", "1", CVAR_ARCHIVE},
@@ -1644,6 +1647,12 @@ void CG_UpdateCvars( void ) {
 	if ( ratStatusbarModificationCount != cg_ratStatusbar.modificationCount ) {
 		CG_RegisterNumbers();
 		ratStatusbarModificationCount = cg_ratStatusbar.modificationCount;
+	}
+	
+	if ( hudMovementKeysModificationCount != cg_hudMovementKeys.modificationCount && !hudMovementKeysRegistered ) {
+		CG_RegisterMovementKeysShaders();
+		hudMovementKeysRegistered = qtrue;
+		hudMovementKeysModificationCount = cg_hudMovementKeys.modificationCount;
 	}
 }
 
@@ -2688,13 +2697,11 @@ static void CG_RegisterGraphics( void ) {
 			break;
 	}
 	
-	cgs.media.movementKeyIndicatorCrouch = trap_R_RegisterShaderNoMip("movementKeyIndicatorCrouch");
-	cgs.media.movementKeyIndicatorJump = trap_R_RegisterShaderNoMip("movementKeyIndicatorJump");
-	cgs.media.movementKeyIndicatorUp = trap_R_RegisterShaderNoMip("movementKeyIndicatorUp");
-	cgs.media.movementKeyIndicatorDown = trap_R_RegisterShaderNoMip("movementKeyIndicatorDown");
-	cgs.media.movementKeyIndicatorLeft = trap_R_RegisterShaderNoMip("movementKeyIndicatorLeft");
-	cgs.media.movementKeyIndicatorRight = trap_R_RegisterShaderNoMip("movementKeyIndicatorRight");
-
+	if (cg_hudMovementKeys.integer) {
+		CG_RegisterMovementKeysShaders();
+		hudMovementKeysRegistered = qtrue;
+	}
+	
 	if (cg_drawZoomScope.integer) {
 		cgs.media.zoomScopeMGShader = trap_R_RegisterShader("zoomScopeMG");
 		cgs.media.zoomScopeRGShader = trap_R_RegisterShader("zoomScopeRG");
@@ -2817,6 +2824,14 @@ static void CG_RegisterGraphics( void ) {
 */
 }
 
+static void CG_RegisterMovementKeysShaders(void) {
+	cgs.media.movementKeyIndicatorCrouch = trap_R_RegisterShaderNoMip("movementKeyIndicatorCrouch");
+	cgs.media.movementKeyIndicatorJump = trap_R_RegisterShaderNoMip("movementKeyIndicatorJump");
+	cgs.media.movementKeyIndicatorUp = trap_R_RegisterShaderNoMip("movementKeyIndicatorUp");
+	cgs.media.movementKeyIndicatorDown = trap_R_RegisterShaderNoMip("movementKeyIndicatorDown");
+	cgs.media.movementKeyIndicatorLeft = trap_R_RegisterShaderNoMip("movementKeyIndicatorLeft");
+	cgs.media.movementKeyIndicatorRight = trap_R_RegisterShaderNoMip("movementKeyIndicatorRight");
+}
 
 
 /*																																			

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -683,7 +683,7 @@ static cvarTable_t cvarTable[] = { // bk001129
 	{ &cg_hudDamageIndicatorScale, "cg_hudDamageIndicatorScale", "1.0", CVAR_ARCHIVE},
 	{ &cg_hudDamageIndicatorOffset, "cg_hudDamageIndicatorOffset", "0.0", CVAR_ARCHIVE},
 	{ &cg_hudDamageIndicatorAlpha, "cg_hudDamageIndicatorAlpha", "1.0", CVAR_ARCHIVE},
-	{ &cg_hudMovementKeys, "cg_hudMovementKeys", "0", CVAR_ARCHIVE},
+	{ &cg_hudMovementKeys, "cg_hudMovementKeys", "0", CVAR_ARCHIVE | CVAR_LATCH},
 	{ &cg_hudMovementKeysScale, "cg_hudMovementKeysScale", "1.0", CVAR_ARCHIVE},
 	{ &cg_hudMovementKeysColor, "cg_hudMovementKeysColor", "H0 0.0 1.0", CVAR_ARCHIVE},
 	{ &cg_emptyIndicator, "cg_emptyIndicator", "1", CVAR_ARCHIVE},

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -246,6 +246,9 @@ vmCvar_t	cg_hudDamageIndicator;
 vmCvar_t	cg_hudDamageIndicatorScale;
 vmCvar_t	cg_hudDamageIndicatorOffset;
 vmCvar_t	cg_hudDamageIndicatorAlpha;
+vmCvar_t	cg_hudMovementKeys;
+vmCvar_t	cg_hudMovementKeysScale;
+vmCvar_t	cg_hudMovementKeysColor;
 vmCvar_t	cg_emptyIndicator;
 vmCvar_t	cg_reloadIndicator;
 vmCvar_t	cg_reloadIndicatorY;
@@ -680,6 +683,9 @@ static cvarTable_t cvarTable[] = { // bk001129
 	{ &cg_hudDamageIndicatorScale, "cg_hudDamageIndicatorScale", "1.0", CVAR_ARCHIVE},
 	{ &cg_hudDamageIndicatorOffset, "cg_hudDamageIndicatorOffset", "0.0", CVAR_ARCHIVE},
 	{ &cg_hudDamageIndicatorAlpha, "cg_hudDamageIndicatorAlpha", "1.0", CVAR_ARCHIVE},
+	{ &cg_hudMovementKeys, "cg_hudMovementKeys", "0", CVAR_ARCHIVE},
+	{ &cg_hudMovementKeysScale, "cg_hudMovementKeysScale", "1.0", CVAR_ARCHIVE},
+	{ &cg_hudMovementKeysColor, "cg_hudMovementKeysColor", "H0 0.0 1.0", CVAR_ARCHIVE},
 	{ &cg_emptyIndicator, "cg_emptyIndicator", "1", CVAR_ARCHIVE},
 	{ &cg_reloadIndicator, "cg_reloadIndicator", "0", CVAR_ARCHIVE},
 	{ &cg_reloadIndicatorY, "cg_reloadIndicatorY", "340", CVAR_ARCHIVE},
@@ -2681,6 +2687,13 @@ static void CG_RegisterGraphics( void ) {
 			cgs.media.damageIndicatorLeft = trap_R_RegisterShaderNoMip("damageIndicatorLeft");
 			break;
 	}
+	
+	cgs.media.movementKeyIndicatorCrouch = trap_R_RegisterShaderNoMip("movementKeyIndicatorCrouch");
+	cgs.media.movementKeyIndicatorJump = trap_R_RegisterShaderNoMip("movementKeyIndicatorJump");
+	cgs.media.movementKeyIndicatorUp = trap_R_RegisterShaderNoMip("movementKeyIndicatorUp");
+	cgs.media.movementKeyIndicatorDown = trap_R_RegisterShaderNoMip("movementKeyIndicatorDown");
+	cgs.media.movementKeyIndicatorLeft = trap_R_RegisterShaderNoMip("movementKeyIndicatorLeft");
+	cgs.media.movementKeyIndicatorRight = trap_R_RegisterShaderNoMip("movementKeyIndicatorRight");
 
 	if (cg_drawZoomScope.integer) {
 		cgs.media.zoomScopeMGShader = trap_R_RegisterShader("zoomScopeMG");

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -2370,6 +2370,16 @@ void Pmove (pmove_t *pmove) {
 		pmove->ps->commandTime = finalTime - 1000;
 	}
 
+	// Send movement keys to the client.
+	pmove->ps->stats[STAT_MOVEMENT_KEYS] = 0
+		| (pmove->cmd.upmove > 0 ? MOVEMENT_KEY_JUMP : 0)
+		| (pmove->cmd.upmove < 0 ? MOVEMENT_KEY_CROUCH : 0)
+		| (pmove->cmd.forwardmove > 0 ? MOVEMENT_KEY_UP : 0)
+		| (pmove->cmd.forwardmove < 0 ? MOVEMENT_KEY_DOWN : 0)
+		| (pmove->cmd.rightmove > 0 ? MOVEMENT_KEY_RIGHT : 0)
+		| (pmove->cmd.rightmove < 0 ? MOVEMENT_KEY_LEFT : 0)
+	;
+
 	pmove->ps->pmove_framecount = (pmove->ps->pmove_framecount+1) & ((1<<PS_PMOVEFRAMECOUNTBITS)-1);
 
 	// chop the move up if it is too long, to prevent framerate

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -259,7 +259,8 @@ typedef enum {
 	STAT_EXTFLAGS,					// extended playerstate flags
 	STAT_BOBCYCLEREM,				// used to store fractions of bobCycle for consistent, FPS-independent footsteps
 	STAT_OVERBOUNCE,					// Overbounce flag (only 1 bit, this could be integrated into another bitflag field if more STAT_ fields are required)
-	STAT_FROZENSTATE				// used to store frozen/thawing state if g_freeze = 1
+	STAT_FROZENSTATE,				// used to store frozen/thawing state if g_freeze = 1
+	STAT_MOVEMENT_KEYS				// used to store key presses.
 } statIndex_t;
 
 
@@ -290,6 +291,14 @@ typedef enum {
 // stats[STAT_EXTFLAGS]
 #define EXTFL_ZOOMING 1
 
+
+// stats[STAT_MOVEMENT_KEYS]
+#define MOVEMENT_KEY_UP     1
+#define MOVEMENT_KEY_DOWN   2
+#define MOVEMENT_KEY_LEFT   4
+#define MOVEMENT_KEY_RIGHT  8
+#define MOVEMENT_KEY_JUMP   16
+#define MOVEMENT_KEY_CROUCH 32
 
 // entityState_t->eFlags
 #define	EF_DEAD				0x00000001		// don't draw a foe marker over players with EF_DEAD


### PR DESCRIPTION
This adds an option to show arrow keys on the HUD like Defrag does. The use of this is that players can watch each other's key presses when learning new movement.

This adds three client cvars
`cg_hudMovementKeys`: Set to 1 to show key presses on the HUD.
`cg_hudMovementKeysScale`: Sets the size of the arrows.
`cg_hudMovementKeysColor`: Sets the HSV color of the arrows.

This patch uses six new TGA files and a modified HUD shader. These can be found on Discord in the file "arrow-keys-hud.pk3".