### PR TITLE
Make `g_smoothStairs` work a little better with ramp jump.

### DIFF
--- a/code/game/bg_slidemove.c
+++ b/code/game/bg_slidemove.c
@@ -298,7 +298,24 @@ void PM_StepSlideMove( qboolean gravity ) {
 	}
 	if ( trace.fraction < 1.0 ) {
 		if (pm->pmove_ratflags & RAT_SMOOTHSTAIRS) {
-			PM_OneSidedClipVelocity( pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP );
+			/*
+			Only clip double sided when...
+			    Rampjump is enabled.
+			    The player is alive.
+			    Jump is pressed, but not held.
+			    A ramp jump is about to occur.
+			*/
+			if ( (pm->pmove_ratflags & RAT_RAMPJUMP) &&
+			    !(pm->ps->pm_flags & PMF_RESPAWNED) &&
+			    !(pm->cmd.upmove < 10) &&
+			    !(pm->ps->pm_flags & PMF_JUMP_HELD) &&
+			    // I don't really need to check for this, but it should prevent interference with additive jump.
+			     (pm->ps->stats[STAT_JUMPTIME] > 0)) {
+				PM_ClipVelocity( pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP );
+			}
+			else {
+				PM_OneSidedClipVelocity( pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP );
+			}
 		} else {
 			PM_ClipVelocity( pm->ps->velocity, trace.plane.normal, pm->ps->velocity, OVERCLIP );
 		}


### PR DESCRIPTION
Ramp jump does not work well with smooth stairs because stepping does not kill upward velocity, and jumping is prevented when the player has upward velocity. This patch allows upward velocity clips only when a ramp jump is about to occur. Double jumping up stairs should now be easy. Some maps still will not work well with smooth stairs. I doubt cpm3a's jump to mega is possible in one jump, and if it is, the technique to do so will change slightly. Same for some of the jumps on hub3aeroq3, and probably hub3aeroq3a. The problem is that the easiest way to perform some of those jumps is to jump, step (and clip), CJ, then jump again, resulting in a ramp jump with high horizontal speed. Smooth stairs will not clip on the step, so the player is still in the air when he is supposed to be performing a CJ. Ramp jumping up a single step will also be difficult, but large steps should be fine since there is plenty of time to press jump again.