### PR TITLE
Give Rat Mode four axes of symmetry, along with high maneuverability …

### DIFF
--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -214,6 +214,15 @@ void PM_OneSidedClipVelocity( vec3_t in, vec3_t normal, vec3_t out, float overbo
 	}
 }
 
+/*
+==================
+PM_HorizontalVectorLength
+==================
+*/
+static ID_INLINE vec_t PM_HorizontalVectorLength( const vec3_t v ) {
+	return (vec_t)sqrt (v[0]*v[0] + v[1]*v[1]);
+}
+
 
 /*
 ==================
@@ -864,7 +873,16 @@ static void PM_AirMove( void ) {
 	}
 	// end Xonotic Darkplaces Air Control
 	
-	if (pm->pmove_movement) {
+	switch (pm->pmove_movement) {
+	case MOVEMENT_RM:
+		if (((fmove == 0 && smove != 0) || (fmove != 0 && smove == 0)) &&
+		    (PM_HorizontalVectorLength(pm->ps->velocity) > wishspeed)) {
+			
+			wishspeed = PM_GetAirStrafeWishspeed(pm);
+			accel = PM_GetAirStrafeAccelerate(pm);
+		}
+		break;
+	default:
 		if (fmove == 0 && smove != 0) {
 			wishspeed = PM_GetAirStrafeWishspeed(pm);
 			accel = PM_GetAirStrafeAccelerate(pm);


### PR DESCRIPTION
…at low speed.

I have no idea if you will like this change or not. I briefly mentioned this once, but didn't go into detail, and I'm sure that you are perfectly happy with Rat Mode as it is.

This changes air movement. At speeds lower than the player's wishspeed, any direction will give you normal RM acceleration. At speeds above the player's wishspeed, QW-style movement will apply when pressing any one horizontal direction key.

Goals:

* Allow strafing in a circle with weapons pointed at the enemy.
* Keep low speed movement as high as baseoa.