### PR TITLE
Crouch slide

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1611,7 +1611,6 @@ typedef struct {
     int		predictedMissileNudge;
     int		ratFlags;
     movement_t	movement;
-    float	slideSlowAccel;
     float	maxBrightshellAlpha;
     int		timeoutEnd;
     int		timeoutOvertime;

--- a/code/cgame/cg_predict.c
+++ b/code/cgame/cg_predict.c
@@ -867,8 +867,6 @@ void CG_PredictPlayerState( void ) {
         cg_pmove.pmove_flags = cgs.dmflags;
         cg_pmove.pmove_ratflags = cgs.ratFlags;
         cg_pmove.pmove_movement = cgs.movement;
-        cg_pmove.pmove_slideSlowAccel = cgs.slideSlowAccel;
-        
 
 //unlagged - optimized prediction
 	// Like the comments described above, a player's state is entirely

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -1059,8 +1059,6 @@ void CG_ParseServerinfo( void ) {
 		cgs.movement = MOVEMENT_VQ3;
 	}
 	
-	cgs.slideSlowAccel = atof( Info_ValueForKey( info, "g_slideSlowAccel" ) );
-
 	cgs.maxBrightshellAlpha = atof( Info_ValueForKey( info, "g_maxBrightshellAlpha" ) );
 	// don't allow the server to set values that are too high / low
 	cgs.maxBrightshellAlpha = MAX(MIN(cgs.maxBrightshellAlpha, 0.8), 0.1);

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1725,6 +1725,7 @@ static void PM_Footsteps( void ) {
 		else {
 			PM_ContinueLegsAnim( LEGS_WALKCR );
 		}
+		footstep = qtrue;
 		// ducked characters never play footsteps
 	/*
 	} else 	if ( pm->ps->pm_flags & PMF_BACKWARDS_RUN ) {
@@ -2371,6 +2372,8 @@ void PmoveSingle (pmove_t *pmove) {
 		pm->ps->stats[STAT_JUMPTIME] -= pml.msec;
 	}
 
+	// This highly complex piece of code determines when to decrement the slide
+	// timer. The slide is sometimes killed here as well.
 	if ((pm->pmove_ratflags & RAT_SLIDEMODE) && (VectorLength(pm->ps->velocity) < crouchWishspeed)) {
 		pm->ps->stats[STAT_EXTFLAGS] &= ~EXTFL_SLIDING;
 	}

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1725,7 +1725,7 @@ static void PM_Footsteps( void ) {
 		else {
 			PM_ContinueLegsAnim( LEGS_WALKCR );
 		}
-		footstep = qtrue;
+		footstep = pm->ps->stats[STAT_EXTFLAGS] & EXTFL_SLIDING;
 		// ducked characters never play footsteps
 	/*
 	} else 	if ( pm->ps->pm_flags & PMF_BACKWARDS_RUN ) {

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -251,7 +251,6 @@ typedef struct {
         int                     pmove_ratflags;
         // Selects between VQ3, CPM, and RM.
         movement_t              pmove_movement;
-        float                   pmove_slideSlowAccel;
 
 	// callbacks to test the world
 	// these will be different functions during game and cgame

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -1514,7 +1514,6 @@ void ClientThink_real( gentity_t *ent ) {
         pm.pmove_flags = g_dmflags.integer;
         pm.pmove_ratflags = g_ratFlags.integer;
         pm.pmove_movement = g_movement.integer;
-        pm.pmove_slideSlowAccel = g_slideSlowAccel.value;
 
 	VectorCopy( client->ps.origin, client->oldOrigin );
 

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1660,7 +1660,6 @@ extern  vmCvar_t        g_newShotgun;
 extern  vmCvar_t        g_movement;
 extern  vmCvar_t        g_crouchSlide;
 extern  vmCvar_t        g_slideMode;
-extern  vmCvar_t        g_slideSlowAccel;
 extern  vmCvar_t        g_rampJump;
 extern  vmCvar_t        g_additiveJump;
 extern  vmCvar_t        g_fastSwim;

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -245,7 +245,6 @@ vmCvar_t        g_newShotgun;
 vmCvar_t        g_movement;
 vmCvar_t        g_crouchSlide;
 vmCvar_t        g_slideMode;
-vmCvar_t        g_slideSlowAccel;
 vmCvar_t        g_rampJump;
 vmCvar_t        g_additiveJump;
 vmCvar_t        g_fastSwim;
@@ -637,7 +636,6 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &g_movement,   "g_movement", "0", CVAR_ARCHIVE | CVAR_SERVERINFO, 0, qtrue },
 	{ &g_crouchSlide,   "g_crouchSlide", "0", CVAR_ARCHIVE, 0, qtrue },
 	{ &g_slideMode,   "g_slideMode", "0", CVAR_ARCHIVE, 0, qtrue },
-	{ &g_slideSlowAccel,   "g_slideSlowAccel", "-0.5", CVAR_SERVERINFO, 0, qtrue },
 	{ &g_rampJump,     "g_rampJump", "0", CVAR_ARCHIVE, 0, qtrue },
 	{ &g_additiveJump,     "g_additiveJump", "1", CVAR_ARCHIVE, 0, qtrue },
 	{ &g_fastSwim,   "g_fastSwim", "1", CVAR_ARCHIVE, 0, qtrue },


### PR DESCRIPTION
There are two modes.
0: Negative accel only. Slide will persist as long as you do not release all keys or turn against your momentum.
1: Positive accel for a brief moment which transitions into negative accel. Slide will cancel if you move less than normal crouch speed or you turn against your momentum.

Slide sound is currently footsteps. A new sound (four, actually) is needed.