### PR TITLE
only ask for consent if /trackconsent/ is included in g_voteNames

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -1481,6 +1481,9 @@ void CG_RatInitDefaults(void)  {
 }
 
 void CG_CheckTrackConsent(void)  {
+	if ( !((int)CG_Cvar_Get("cg_voteflags") & VF_trackconsent) ) {
+		return;
+	}
 	if ((int)CG_Cvar_Get("ui_trackConsentConfigured") != 0) {
 		return;
 	}

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -866,7 +866,7 @@ qboolean	BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
 
 //g_voteflags->integer
 //Autoparsed from allowedvote
-//List: "/map_restart/nextmap/map/g_gametype/kick/clientkick/g_doWarmup/timelimit/fraglimit/custom/shuffle/"
+//List: "/map_restart/nextmap/map/g_gametype/kick/clientkick/g_doWarmup/timelimit/fraglimit/custom/shuffle/trackconsent/"
 #define VF_map_restart  1
 #define VF_nextmap      2
 #define VF_map          4
@@ -878,6 +878,7 @@ qboolean	BG_CanItemBeGrabbed( int gametype, const entityState_t *ent, const play
 #define VF_fraglimit    128
 #define VF_custom       256
 #define VF_shuffle      512
+#define VF_trackconsent 1024
 
 //g_ratFlags->integer
 // autoparsed from various ratmod cvars

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -1786,6 +1786,9 @@ void G_UpdateCvars( void ) {
                                     if( allowedVote("custom") )
                                         voteflags|=VF_custom;
 
+                                    if( allowedVote("trackconsent") )
+                                        voteflags|=VF_trackconsent;
+
                                     trap_Cvar_Set("voteflags",va("%i",voteflags));
                                 }
       
@@ -2075,6 +2078,9 @@ void G_InitGame( int levelTime, int randomSeed, int restart ) {
 
             if( allowedVote("custom") )
                 voteflags|=VF_custom;
+
+            if( allowedVote("trackconsent") )
+                voteflags|=VF_trackconsent;
 
             trap_Cvar_Set("voteflags",va("%i",voteflags));
         }


### PR DESCRIPTION
Only display consent popup if the server is configured to do so. I used `voteflags` instead of trying to cram it into the `g_ratFlags`. It also seems like a fairly logical way to do it without introducing a new CVar.

This also fixes the popup that appears in single player after installing Ratmod for the first time. Before the fix, the user might get the impression that something is being sent to a remote server.