### PR TITLE
fix stringify

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -981,7 +981,7 @@ void CG_SetEngineCvars( void ) {
 }
 
 
-#define LATEST_RATINITIALIZED 38
+#define LATEST_RATINITIALIZED 39
 
 int CG_MigrateOldCrosshair(int old) {
 	switch (old) {
@@ -1499,6 +1499,14 @@ void CG_RatOldCfgUpdate(void) {
 		}
 
 		CG_Cvar_SetAndUpdate( "cg_ratInitialized", "38" );
+	}
+
+	if (cg_ratInitialized.integer < 39) {
+		if ((int)CG_Cvar_Get("snaps") <= 0) {
+			CG_SetEngineCvars();
+		}
+
+		CG_Cvar_SetAndUpdate( "cg_ratInitialized", "39" );
 	}
 }
 

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -63,7 +63,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define DEFAULT_SV_FPS		40
 
-#define STRINGIFY(a) #a
+#define STRINGIFY_HELPER(a) #a
+#define STRINGIFY(a) STRINGIFY_HELPER(a)
 
 //
 // config strings are a general means of communicating variable length strings


### PR DESCRIPTION
The bug caused \snaps to be set to an unintended value, which would be interpreted as an integer value of 0, making the game unplayable.